### PR TITLE
Add Go Wrapper for SQISign with Example Usage (First Iteration)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/the-sqisign"]
+	path = external/the-sqisign
+	url = https://github.com/SQISign/the-sqisign

--- a/README.md
+++ b/README.md
@@ -1,1 +1,78 @@
 # sqisign-go
+
+`sqisign-go` is a Go wrapper around the SQISign cryptographic library. It
+provides functionality to generate keypairs, sign messages, and verify
+signatures using the SQISign post-quantum signature algorithm. The wrapper
+integrates with the `libsqisign_lvl1.a` static library from the SQISign project.
+
+## ⚠️ Current Status
+
+**This repository is in stand-by mode.** The SQISign algorithm implementation
+contains unresolved issues regarding its build, as noted in the [SQISign
+GitHub issue #4](https://github.com/SQISign/the-sqisign/issues/4). Therefore,
+this wrapper will not work until these issues are resolved.
+
+## Getting Started
+
+### Prerequisites
+
+Ensure you have the following installed on your system:
+- GCC with support for modern standards.
+- Go programming language (version 1.15+ recommended).
+- CMake for building the external library.
+
+### Clone the Repository
+
+First, clone the `sqisign-go` repository:
+
+```bash
+git clone --recurse-submodules https://github.com/gabrielzschmitz/sqisign-go.git
+cd sqisign-go
+```
+
+If you have already cloned the repository without submodules, you can initialize
+and update them using:
+
+```bash
+git submodule update --init --recursive
+```
+
+### Build the External Library
+
+The Go wrapper depends on the `libsqsisign_lvl1.a` static library, which needs
+to be built from the SQISign project.
+
+To build the library:
+
+1. Navigate to the SQISign project directory:
+   ```bash
+   cd external/the-sqisign
+   ```
+2. Create a build directory and configure the project with CMake:
+   ```bash
+   mkdir -p build
+   cd build
+   cmake -DSQISIGN_BUILD_TYPE=ref ..
+   make
+   ```
+
+This will generate necessary librarys inside `build/src/`.
+
+### Build the Go Project
+
+Once the library is built, you can compile and run the Go project!
+
+```bash
+go build .
+go run .
+```
+
+### Notes
+- Ensure the library paths in `CGO_CFLAGS` and `CGO_LDFLAGS` are adjusted to
+  match your build directory structure.
+- See the [⚠️ Current Status](#⚠️-current-status) section for details about the
+  upstream issue affecting this repository.
+
+## License
+
+This project is licensed under the MIT License.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module sqisign-go
+
+go 1.23.2

--- a/main.go
+++ b/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "sqisign-go/sqisign" 
+)
+
+func main() {
+    // Generate a keypair
+    pk, sk, err := sqisign.Keypair()
+    if err != nil {
+        log.Fatalf("Error generating keypair: %v", err)
+    }
+
+    fmt.Printf("Public Key: %x\n", pk)
+    fmt.Printf("Secret Key: %x\n", sk)
+}

--- a/sqisign/sqisign.go
+++ b/sqisign/sqisign.go
@@ -1,0 +1,94 @@
+package sqisign
+
+/*
+#cgo CFLAGS: -I../external/the-sqisign/src -I../external/the-sqisign/src/protocols/ref/include
+#cgo LDFLAGS: -L../external/the-sqisign/src/protocols/ref/lvl1 -lsqisign_protocols_lvl1 -static
+
+#include "sqisign.h"
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"fmt"
+	"errors"
+	"unsafe"
+)
+
+const (
+    PublicKeyBytes = 64   // CRYPTO_PUBLICKEYBYTES
+    SecretKeyBytes = 64   // CRYPTO_SECRETKEYBYTES
+    SignatureBytes = 177  // CRYPTO_BYTES
+)
+
+// Keypair generates a public/private keypair.
+func Keypair() ([]byte, []byte, error) {
+    pk := make([]byte, PublicKeyBytes)
+    sk := make([]byte, SecretKeyBytes)
+
+    ret := C.sqisign_keypair((*C.uchar)(unsafe.Pointer(&pk[0])), (*C.uchar)(unsafe.Pointer(&sk[0])))
+    if ret != 0 {
+        return nil, nil, errors.New("failed to generate keypair")
+    }
+
+    return pk, sk, nil
+}
+
+// Sign signs the message `m` with the secret key `sk` and returns the signed message.
+func Sign(m []byte, sk []byte) ([]byte, error) {
+    sm := make([]byte, len(m)+SignatureBytes) // Buffer for signature + message
+    smlen := C.ulonglong(0)
+
+    ret := C.sqisign_sign(
+        (*C.uchar)(unsafe.Pointer(&sm[0])),
+        (*C.ulonglong)(unsafe.Pointer(&smlen)),
+        (*C.uchar)(unsafe.Pointer(&m[0])),
+        C.ulonglong(len(m)),
+        (*C.uchar)(unsafe.Pointer(&sk[0])),
+    )
+    if ret != 0 {
+        return nil, errors.New("failed to sign message")
+    }
+
+    return sm[:smlen], nil
+}
+
+// Open verifies the signed message `sm` with the public key `pk` and returns the original message.
+func Open(sm []byte, pk []byte) ([]byte, error) {
+    m := make([]byte, len(sm)-SignatureBytes) // Buffer for original message
+    mlen := C.ulonglong(0)
+
+    ret := C.sqisign_open(
+        (*C.uchar)(unsafe.Pointer(&m[0])),
+        (*C.ulonglong)(unsafe.Pointer(&mlen)),
+        (*C.uchar)(unsafe.Pointer(&sm[0])),
+        C.ulonglong(len(sm)),
+        (*C.uchar)(unsafe.Pointer(&pk[0])),
+    )
+    if ret != 0 {
+        return nil, errors.New("failed to open signed message")
+    }
+
+    return m[:mlen], nil
+}
+
+// Verify verifies the signature `sig` of the message `m` with the public key `pk`.
+func Verify(m []byte, sig []byte, pk []byte) (bool, error) {
+    ret := C.sqisign_verify(
+        (*C.uchar)(unsafe.Pointer(&m[0])),
+        C.ulonglong(len(m)),
+        (*C.uchar)(unsafe.Pointer(&sig[0])),
+        C.ulonglong(len(sig)),
+        (*C.uchar)(unsafe.Pointer(&pk[0])),
+    )
+    if ret != 0 {
+        return false, errors.New("failed to verify signature")
+    }
+
+    return true, nil
+}
+
+func main() {
+    fmt.Println("Hello, World!")
+
+    fmt.Println("testing sqisign access!")
+}

--- a/sqisign/sqisign.go
+++ b/sqisign/sqisign.go
@@ -33,7 +33,7 @@ func Keypair() ([]byte, []byte, error) {
     return pk, sk, nil
 }
 
-// Sign signs the message `m` with the secret key `sk` and returns the signed message.
+// Sign signs the hashed message `m` with the secret key `sk` and returns the signed message.
 func Sign(m []byte, sk []byte) ([]byte, error) {
     sm := make([]byte, len(m)+SignatureBytes) // Buffer for signature + message
     smlen := C.ulonglong(0)

--- a/sqisign/sqisign.h
+++ b/sqisign/sqisign.h
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef SQISIGN_H
+#define SQISIGN_H
+
+#include <stdint.h>
+
+/**
+ * SQIsign keypair generation.
+ *
+ * The implementation corresponds to SQIsign.CompactKeyGen() in the SQIsign spec.
+ * The caller is responsible to allocate sufficient memory to hold pk and sk.
+ *
+ * @param[out] pk SQIsign public key
+ * @param[out] sk SQIsign secret key
+ * @return int status code
+ */
+int sqisign_keypair(unsigned char *pk, unsigned char *sk);
+
+/**
+ * SQIsign signature generation.
+ *
+ * The implementation performs SQIsign.expandSK() + SQIsign.sign() in the SQIsign spec.
+ * Keys provided is a compacted secret keys.
+ * The caller is responsible to allocate sufficient memory to hold sm.
+ *
+ * @param[out] sm Signature concatenated with message
+ * @param[out] smlen Pointer to the length of sm
+ * @param[in] m Message to be signed
+ * @param[in] mlen Message length
+ * @param[in] sk Compacted secret key
+ * @return int status code
+ */
+int sqisign_sign(unsigned char *sm,
+              unsigned long long *smlen, const unsigned char *m,
+              unsigned long long mlen, const unsigned char *sk);
+
+/**
+ * SQIsign open signature.
+ *
+ * The implementation performs SQIsign.verify(). If the signature verification succeeded, the original message is stored in m.
+ * Keys provided is a compact public key.
+ * The caller is responsible to allocate sufficient memory to hold m.
+ *
+ * @param[out] m Message stored if verification succeeds
+ * @param[out] mlen Pointer to the length of m
+ * @param[in] sm Signature concatenated with message
+ * @param[in] smlen Length of sm
+ * @param[in] pk Compacted public key
+ * @return int status code
+ */
+int sqisign_open(unsigned char *m,
+              unsigned long long *mlen, const unsigned char *sm,
+              unsigned long long smlen, const unsigned char *pk);
+
+
+/**
+ * SQIsign verify signature.
+ *
+ * If the signature verification succeeded, returns 0, otherwise 1.
+ *
+ * @param[out] m Message stored if verification succeeds
+ * @param[out] mlen Pointer to the length of m
+ * @param[in] sig Signature
+ * @param[in] siglen Length of sig
+ * @param[in] pk Compacted public key
+ * @return int 0 if verification succeeded, 1 otherwise.
+ */
+int sqisign_verify(const unsigned char *m,
+                unsigned long long mlen, const unsigned char *sig,
+                unsigned long long siglen, const unsigned char *pk);
+
+#endif


### PR DESCRIPTION
#### **Overview**
This pull request introduces the integration of the SQISign library into the project with a Go wrapper, using CGo for bindings. It also sets up an example application to demonstrate basic functionality. This includes three main changes:

1. **Adding SQISign as a submodule**.
2. **Creating a Go package to interface with SQISign**.
3. **Initializing the Go module and providing an example usage**.

#### **Changes**

1. **SQISign Submodule Integration** (`chore(external): add SQISign as a submodule`)
   - Added the SQISign library as a submodule under `external/the-sqisign`.
   - The submodule is linked to commit `ff34a8c` in the official SQISign repository.

2. **Go Wrapper for SQISign** (`feat(binding): add Go wrapper for SQISign library`)
   - Created a Go package named `sqisign` with CGo bindings to the SQISign library.
   - Implemented core functions to handle:
     - `Keypair`: Generates a public/private keypair.
     - `Sign`: Signs a message using the secret key.
     - `Open`: Verifies and extracts the original message from a signed message.
     - `Verify`: Verifies the signature of a given message with a public key.

3. **Go Module Setup and Example** (`feat(core): initialize Go module and add example for SQISign`)
   - Initialized the Go module as `sqisign-go` with Go version 1.23.2.
   - Added `main.go` to demonstrate the basic usage of the SQISign wrapper.
     - Example generates a keypair and prints the public and secret keys.

#### **Notes**
- Before anything make sure to clone the repo with the necessary submodules: `git clone --recurse-submodules <repository-url>`
- Make sure to follow the build instructions at [SQISign](https://github.com/SQISign/the-sqisign).
- The wrapper is currently limited to key generation, signing, and verification operations. Future extensions could include additional SQISign features.
- The wrapper still don't work as intended and need to be fixed until the approve of this pull request.
- The Go example in `main.go` serves as a quick-start demonstration and can be expanded to cover more comprehensive use cases.

#### **References**
- [SQISign](https://github.com/SQISign/the-sqisign) GitHub Repository
- Go Documentation on [CGo](https://pkg.go.dev/cmd/cgo)

**Closes #1**